### PR TITLE
adding support for syncMessages request attribute

### DIFF
--- a/pipeline/receive.go
+++ b/pipeline/receive.go
@@ -29,6 +29,12 @@ type ReceiveRequest struct {
 	// specified, SYNC envelopes are not sent. If specified, it has to be
 	// greater than or equal to 5s.
 	SyncInterval time.Duration
+	// The SYNC envelopes can also be sent every "N" messages. If only the
+	// SyncMessages parameter is present and if at any point the number of
+	// messages consumed is less than the number specified and there are no
+	// new messages to be consumed from the topic for 5 seconds, a SYNC
+	// envelope will be sent after 5 seconds.
+	SyncMessages int
 	// If specified, send only messages for these IMS organizations.
 	Organizations []string
 	// If specified, send only messages from these sources.
@@ -161,6 +167,10 @@ func receiveURL(pipelineURL, group, topic string, r *ReceiveRequest) string {
 
 	if r.SyncInterval != 0 {
 		values.Set("syncInterval", fmt.Sprintf("%d", r.SyncInterval.Milliseconds()))
+	}
+
+	if r.SyncMessages != 0 {
+		values.Set("syncMessages", fmt.Sprintf("%d", r.SyncMessages))
 	}
 
 	if r.Organizations != nil {

--- a/pipeline/receive_test.go
+++ b/pipeline/receive_test.go
@@ -57,6 +57,19 @@ func TestReceiveURLWithSyncInterval(t *testing.T) {
 	}
 }
 
+func TestReceiveURLWithSyncMessages(t *testing.T) {
+	u, err := url.Parse(receiveURL("https://www.acme.com", "g", "t", &ReceiveRequest{
+		SyncMessages: 10,
+	}))
+	if err != nil {
+		t.Fatalf("parse URL: %v", err)
+	}
+
+	if v := u.Query().Get("syncMessages"); v != "10" {
+		t.Fatalf("invalid sync messages: %v", v)
+	}
+}
+
 func TestReceiveURLWithOrganizations(t *testing.T) {
 	u, err := url.Parse(receiveURL("https://www.acme.com", "g", "t", &ReceiveRequest{
 		Organizations: []string{"o1", "o2"},
@@ -66,7 +79,7 @@ func TestReceiveURLWithOrganizations(t *testing.T) {
 	}
 
 	if v := u.Query().Get("org"); v != "o1,o2" {
-		t.Fatalf("invalid sync interval: %v", v)
+		t.Fatalf("invalid organizations: %v", v)
 	}
 }
 


### PR DESCRIPTION
Adding support of SyncMessages request attribute.

## Description
SyncMessages request parameter is beneficial for pipeline consumers which have slow processing of messages and to have a more predictable sync marker. 
Ref: https://pipeline.corp.adobe.com/docs#?30_Developer_Guide.60_HTTP_APIs.30_Consuming_Messages.20_Position_Management

## Related Issue
ACSS-27720

## Motivation and Context
It solves the problem we faced with using sync interval wherein the sync markers were very infrequent/missed from the pipeline leading to topics going in STOP state. Adding support for SyncMessages has helped us in dealing with that.

## How Has This Been Tested?
It has been tested via the unit tests and also in our development environment.

## Screenshots (if appropriate):
More consistent sync commits.
![image](https://user-images.githubusercontent.com/51451239/98508724-fe74e300-2285-11eb-957e-0f55aab7e885.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.