### PR TITLE
fix default client to actually retry requests

### DIFF
--- a/pipeline/client.go
+++ b/pipeline/client.go
@@ -70,7 +70,7 @@ func NewClient(cfg *ClientConfig) (*Client, error) {
 	client := cfg.Client
 
 	if client == nil {
-		client = defaultRetryClient().HTTPClient
+		client = defaultRetryClient().StandardClient()
 	}
 
 	return &Client{


### PR DESCRIPTION
Fix the default http client to actually do retries